### PR TITLE
[FIX] Testes Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ matrix:
       env:
         - TOXENV=docs
     - env:
-        - TOXENV=py27,codecov
-      python: '2.7'
-    - env:
         - TOXENV=py34,codecov
       python: '3.4'
     - env:
@@ -27,9 +24,6 @@ matrix:
     - env:
         - TOXENV=py37,codecov
       python: '3.7'
-    - env:
-        - TOXENV=pypy,codecov
-      python: 'pypy2.7-6.0'
     - env:
         - TOXENV=pypy3,codecov
         - TOXPYTHON=pypy3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,18 +11,6 @@ environment:
       PYTHON_HOME: C:\Python36
       PYTHON_VERSION: '3.6'
       PYTHON_ARCH: '32'
-    - TOXENV: 'py27,codecov'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-      WINDOWS_SDK_VERSION: v7.0
-    - TOXENV: 'py27,codecov'
-      TOXPYTHON: C:\Python27-x64\python.exe
-      PYTHON_HOME: C:\Python27-x64
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '64'
-      WINDOWS_SDK_VERSION: v7.0
     - TOXENV: 'py34,codecov'
       TOXPYTHON: C:\Python34\python.exe
       PYTHON_HOME: C:\Python34

--- a/src/erpbrasil/base/__init__.py
+++ b/src/erpbrasil/base/__init__.py
@@ -1,4 +1,4 @@
 __version__ = '1.2.0'
 
-from erpbrasil.base.fiscal import *  # noqa: F401
-from erpbrasil.base.misc import *  # noqa: F401
+from erpbrasil.base.fiscal import *  # noqa: F401,F403
+from erpbrasil.base.misc import *  # noqa: F401,F403

--- a/tests/test_tools_fiscal.py
+++ b/tests/test_tools_fiscal.py
@@ -53,20 +53,20 @@ class Tests(TestCase):
 
     def test_01_formata_cnpj_cpf(self):
         """Teste formatação de CNPJ/CPF correto"""
-        self.assertEquals(
+        self.assertEqual(
             cnpj_cpf.formata('02960895000131'), '02.960.895/0001-31')
 
     def test_02_formata_cnpj_cpf(self):
         """Teste formatação de CNPJ/CPF correto"""
-        self.assertEquals(
+        self.assertEqual(
             cnpj_cpf.formata('55394836000'), '553.948.360-00')
 
     def test_01_formata_cnpj(self):
         """Teste formatação de CNPJ correto"""
-        self.assertEquals(
+        self.assertEqual(
             cnpj_cpf.formata_cnpj('61103212000199'), '61.103.212/0001-99')
 
     def test_01_formata_cpf(self):
         """Teste formatação de CPF correto"""
-        self.assertEquals(
+        self.assertEqual(
             cnpj_cpf.formata_cpf('06853187024'), '068.531.870-24')

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,13 @@ envlist =
     clean,
     check,
     docs,
-    {py27,py34,py35,py36,py37,pypy,pypy3},
+    {py34,py35,py36,py37,pypy,pypy3},
     report
 
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
     pypy3: {env:TOXPYTHON:pypy3}
-    py27: {env:TOXPYTHON:python2.7}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
     {py36,docs,spell}: {env:TOXPYTHON:python3.6}


### PR DESCRIPTION
Esse PR adiciona as seguintes correções:
- Remove testes para Python2
- Substitui o uso do assertEquals para assertEqual (Depreciado)
- Ignora verificação F403, seguindo o padrão existente para o F401