### PR TITLE
Remover prefixo da chave do edoc

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.2.0
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.org/project/erpbrasil.base
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.base/vvv2.1.0...svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.base/vvv2.2.0...svg
     :alt: Commits since latest release
     :target: https://github.com/erpbrasil/erpbrasil.base/compare/v1.0.0...master
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ project = 'erpbrasil.base'
 year = '2019'
 author = 'Luis Felipe Mileo'
 copyright = '{0}, {1}'.format(year, author)
-version = release = '2.1.0'
+version = release = '2.2.0'
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name='erpbrasil.base',
-    version='2.1.0',
+    version='2.2.0',
     license='MIT license',
     description='Base',
     long_description='%s\n%s' % (

--- a/src/erpbrasil/base/__init__.py
+++ b/src/erpbrasil/base/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 
 from erpbrasil.base.fiscal import *  # noqa: F401,F403
 from erpbrasil.base.misc import *  # noqa: F401,F403

--- a/src/erpbrasil/base/fiscal/edoc.py
+++ b/src/erpbrasil/base/fiscal/edoc.py
@@ -16,16 +16,18 @@ EDOC_PREFIX = {
     '65': 'NFe',
 }
 
+CHAVE_REGEX = re.compile(r'(?P<campos>\d{44})$')
+
 
 def detectar_chave_edoc(chave):
     """ Converte a chave em texto no objeto correto"""
-    CHAVE_REGEX = re.compile(r'(?P<prefixo>\w+)(?P<campos>\d{44})$')
     matcher = CHAVE_REGEX.match(chave)
     if matcher:
         campos = matcher.group('campos')
-        prefixo = matcher.group('prefixo')
-    if not matcher and not prefixo and not campos:
+    if not matcher and not campos:
         raise ValueError('Chave de acesso invalida: {!r}'.format(chave))
+
+    prefixo = EDOC_PREFIX.get(campos[20:22])
 
     if prefixo in ('NFe', 'CTe', 'MDFe'):
         return ChaveEdoc(chave=chave, validar=True)
@@ -51,8 +53,6 @@ class ChaveEdoc(object):
              |  |    |              |  |   |         | |        |
         NFe  35 2103 20695448000184 55 001 000003589 1 98183992 3
     """
-    CHAVE_REGEX = re.compile(r'^(NFe|CTe|MDFe)(?P<campos>\d{44})$')
-
     CUF = slice(0, 2)
     AAMM = slice(2, 6)
     CNPJ = slice(6, 20)
@@ -88,7 +88,7 @@ class ChaveEdoc(object):
             campos += self.calculo_codigo_aleatorio(campos)
             campos += str(modulo11(campos))
         else:
-            matcher = self.CHAVE_REGEX.match(chave)
+            matcher = CHAVE_REGEX.match(chave)
             if matcher:
                 campos = matcher.group('campos')
             if not matcher or not campos:
@@ -96,7 +96,7 @@ class ChaveEdoc(object):
 
         self.campos = campos
         self.prefixo = EDOC_PREFIX.get(self.modelo_documento, '')
-        self.chave = self.prefixo + self.campos
+        self.chave = self.campos
 
         if validar:
             self.validar()
@@ -162,6 +162,14 @@ class ChaveEdoc(object):
     @chave.setter
     def chave(self, value):
         self._chave = value
+
+    @property
+    def prefixo(self):
+        return self._prefixo
+
+    @property
+    def prefixo_chave(self):
+        return self._prefixo + self._chave
 
     @property
     def campos(self):

--- a/tests/test_chave_edoc.py
+++ b/tests/test_chave_edoc.py
@@ -18,7 +18,7 @@ class Tests(TestCase):
         modelo_documento = '58'
         numero_documento = '149000153'
         numero_serie = '000'
-        chave = 'MDFe50131248740351011795580001490001531345952745'
+        chave = '50131248740351011795580001490001531345952745'
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
@@ -62,7 +62,7 @@ class Tests(TestCase):
         numero_documento = '000199075'
         numero_serie = '001'
 
-        chave = 'CTe32171232438772000104570010001990751153183825'
+        chave = '32171232438772000104570010001990751153183825'
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
@@ -106,7 +106,7 @@ class Tests(TestCase):
         numero_documento = '000000599'
         numero_serie = '796'
 
-        chave = 'NFe43140201098983010680657960000005991148127446'
+        chave = '43140201098983010680657960000005991148127446'
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
@@ -150,7 +150,7 @@ class Tests(TestCase):
         numero_documento = '000003589'
         numero_serie = '001'
 
-        chave = 'NFe35210320695448000184550010000035891981839923'
+        chave = '35210320695448000184550010000035891981839923'
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
@@ -185,6 +185,51 @@ class Tests(TestCase):
             'Key: partes failed'
         )
 
+    def test_nfe_prefixo_chave_objeto(self):
+        cnpj = '20.695.448/0001-84'
+        ano_mes = '2103'
+        codigo_uf = 35
+        forma_emissao = '1'
+        modelo_documento = '55'
+        numero_documento = '000003589'
+        numero_serie = '001'
+
+        chave = '35210320695448000184550010000035891981839923'
+        edoc_1 = ChaveEdoc(chave=chave)
+
+        self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
+        self.assertEqual(edoc_1.cnpj_emitente, cnpj, 'Key: cnpj_emitente failed')
+        self.assertEqual(edoc_1.codigo_uf, codigo_uf, 'Key: codigo_uf failed')
+        self.assertEqual(edoc_1.forma_emissao, forma_emissao, 'Key: forma_emissao failed')
+        self.assertEqual(edoc_1.modelo_documento, modelo_documento, 'Key: modelo_documento failed')
+        self.assertEqual(edoc_1.numero_documento, numero_documento, 'Key: numero_documento failed')
+        self.assertEqual(edoc_1.numero_serie, numero_serie, 'Key: numero_serie failed')
+
+        self.assertEqual(edoc_1.ano_emissao, 2021, 'Key: ano_emissao failed')
+        self.assertEqual(edoc_1.codigo_aleatorio, '98183992', 'Key: codigo_aleatorio failed')
+        self.assertEqual(edoc_1.digito_verificador, '3', 'Key: digito_verificador failed')
+        self.assertEqual(edoc_1.mes_emissao, 3, 'Key: mes_emissao failed')
+
+        edoc_2 = ChaveEdoc(
+            ano_mes=ano_mes,
+            cnpj_emitente=cnpj,
+            codigo_uf=codigo_uf,
+            forma_emissao=forma_emissao,
+            modelo_documento=modelo_documento,
+            numero_documento=numero_documento,
+            numero_serie=numero_serie,
+        )
+
+        self.assertEqual(chave, edoc_2.chave)
+        self.assertEqual(edoc_1.chave, chave)
+        self.assertEqual(edoc_1.prefixo_chave, edoc_2.prefixo_chave)
+
+        self.assertEqual(
+            edoc_1.partes(),
+            edoc_2.partes(),
+            'Key: partes failed'
+        )
+
     def test_cfe_chave_objeto(self):
         cnpj = '08.723.218/0001-86'
         ano_mes = '1508'
@@ -194,7 +239,7 @@ class Tests(TestCase):
         numero_documento = '000055'
         numero_serie = '900004019'
 
-        chave = 'CFe35150808723218000186599000040190000557255950'
+        chave = '35150808723218000186599000040190000557255950'
         edoc_1 = ChaveCFeSAT(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
@@ -227,7 +272,7 @@ class Tests(TestCase):
         numero_documento = '000024'
         numero_serie = '900004019'
 
-        chave = 'CFe35150808723218000186599000040190000241114257'
+        chave = '35150808723218000186599000040190000241114257'
         edoc_1 = ChaveCFeSAT(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
@@ -255,14 +300,14 @@ class Tests(TestCase):
 
         chaves_invalidas = [
             # número do CNPJ emitente inválido
-            'CFe35150808723218000187599000040190000241114259',
+            '35150808723218000187599000040190000241114259',
 
             # NF-E
-            'NFe35210320695448000184550010000035891981839924',
+            '35210320695448000184550010000035891981839924',
             # Modelo invalido - 54
-            'NFe35210320695448000184540010000035891981839924',
+            '35210320695448000184540010000035891981839924',
             # NFE em maiusculo
-            'NFE35210320695448000184540010000035891981839924',
+            '35210320695448000184540010000035891981839924',
         ]
         for chave in chaves_invalidas:
             with self.assertRaises(ValueError):
@@ -271,12 +316,12 @@ class Tests(TestCase):
     def test_valid_key(self):
 
         chaves_validas = [
-            'MDFe50131248740351011795580001490001531345952745',
-            'NFe43140201098983010680657960000005991148127446',
-            'NFe35210320695448000184550010000035891981839923',
-            'CTe32171232438772000104570010001990751153183825',
-            'CFe35150808723218000186599000040190000241114257',
-            'CFe35150808723218000186599000040190000557255950'
+            '50131248740351011795580001490001531345952745',
+            '43140201098983010680657960000005991148127446',
+            '35210320695448000184550010000035891981839923',
+            '32171232438772000104570010001990751153183825',
+            '35150808723218000186599000040190000241114257',
+            '35150808723218000186599000040190000557255950'
         ]
         for chave in chaves_validas:
             edoc = detectar_chave_edoc(chave=chave)


### PR DESCRIPTION
Esta alteração tem o objetivo remover a prefixo da propriedade chave do objeto ChaveEdoc

- Também foi alterado a função detectar_chave_edoc para pegar o prefixo através do campo do modelo do documento fiscal (armazenado nas posições 20 a 22 da chave)
- No ChaveEdoc agora existe o atributo chave e prefixo, foi adicionado a propriedade prefixo_chave para imprimir a chave com o prefixo.