### PR TITLE
fix 'campos' referenced before assignment

### DIFF
--- a/src/erpbrasil/base/fiscal/edoc.py
+++ b/src/erpbrasil/base/fiscal/edoc.py
@@ -24,6 +24,8 @@ def detectar_chave_edoc(chave):
     matcher = CHAVE_REGEX.match(chave)
     if matcher:
         campos = matcher.group('campos')
+    else:
+        campos = False
     if not matcher and not campos:
         raise ValueError('Chave de acesso invalida: {!r}'.format(chave))
 


### PR DESCRIPTION
sem isso pega erros do tipo:

```
  File "/odoo/external-src/l10n-brazil/l10n_br_nfe/wizards/import_document.py", line 66, in _onchange_partner_id
    base64.b64decode(self.nfe_xml)
  File "/odoo/external-src/l10n-brazil/l10n_br_nfe/wizards/import_document.py", line 58, in _parse_xml_import_wizard
    document = detectar_chave_edoc(parsed_xml.infNFe.Id[3:])
  File "/usr/local/lib/python3.7/dist-packages/erpbrasil/base/fiscal/edoc.py", line 27, in detectar_chave_edoc
    if not matcher and not campos:
UnboundLocalError: local variable 'campos' referenced before assignment
```

cc @renatonlima 