### PR TITLE
Melhorias na validação da chave dos documentos fiscais

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.3
+current_version = 2.3.0
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.org/project/erpbrasil.base
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.base/vvv2.2.3...svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.base/vvv2.3.0...svg
     :alt: Commits since latest release
     :target: https://github.com/erpbrasil/erpbrasil.base/compare/v1.0.0...master
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ project = 'erpbrasil.base'
 year = '2019'
 author = 'Luis Felipe Mileo'
 copyright = '{0}, {1}'.format(year, author)
-version = release = '2.2.3'
+version = release = '2.3.0'
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ python_files =
     tests.py
 addopts =
     -ra
-    --strict
+    --strict-markers
     --doctest-modules
     --doctest-glob=\*.rst
     --tb=short

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name='erpbrasil.base',
-    version='2.2.3',
+    version='2.3.0',
     license='MIT license',
     description='Base',
     long_description='%s\n%s' % (

--- a/src/erpbrasil/base/__init__.py
+++ b/src/erpbrasil/base/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.2.3'
+__version__ = '2.3.0'
 
 from erpbrasil.base.fiscal import *  # noqa: F401,F403
 from erpbrasil.base.misc import *  # noqa: F401,F403

--- a/src/erpbrasil/base/fiscal/edoc.py
+++ b/src/erpbrasil/base/fiscal/edoc.py
@@ -8,6 +8,38 @@ from ..misc import modulo11
 from ..misc import punctuation_rm
 from . import cnpj_cpf
 
+ESTADOS_IBGE = {
+    11: ["RO", "Rondônia"],
+    12: ["AC", "Acre"],
+    13: ["AM", "Amazonas"],
+    14: ["RR", "Roraima"],
+    15: ["PA", "Pará"],
+    16: ["AP", "Amapá"],
+    17: ["TO", "Tocantins"],
+    21: ["MA", "Maranhão"],
+    22: ["PI", "Piauí"],
+    23: ["CE", "Ceará"],
+    24: ["RN", "Rio Grande do Norte"],
+    25: ["PB", "Paraíba"],
+    26: ["PE", "Pernambuco"],
+    27: ["AL", "Alagoas"],
+    28: ["SE", "Sergipe"],
+    29: ["BA", "Bahia"],
+    31: ["MG", "Minas Gerais"],
+    32: ["ES", "Espírito Santo"],
+    33: ["RJ", "Rio de Janeiro"],
+    35: ["SP", "São Paulo"],
+    41: ["PR", "Paraná"],
+    42: ["SC", "Santa Catarina"],
+    43: ["RS", "Rio Grande do Sul"],
+    50: ["MS", "Mato Grosso do Sul"],
+    51: ["MT", "Mato Grosso"],
+    52: ["GO", "Goiás"],
+    53: ["DF", "Distrito Federal"],
+}
+
+CODIGO_ESTADOS_IBGE = list(ESTADOS_IBGE.keys())
+
 EDOC_PREFIX = {
     '55': 'NFe',
     '57': 'CTe',
@@ -15,6 +47,8 @@ EDOC_PREFIX = {
     '59': 'CFe',
     '65': 'NFe',
 }
+
+CODIGO_MODELOS_EDOC = list(EDOC_PREFIX.keys())
 
 CHAVE_REGEX = re.compile(r'(?P<campos>\d{44})$')
 
@@ -57,7 +91,7 @@ class ChaveEdoc(object):
     """
     CUF = slice(0, 2)
     AAMM = slice(2, 6)
-    CNPJ = slice(6, 20)
+    CNPJ_CPF = slice(6, 20)
     MODELO = slice(20, 22)
     SERIE = slice(22, 25)
     NUMERO = slice(25, 34)
@@ -65,11 +99,11 @@ class ChaveEdoc(object):
     CODIGO = slice(35, 43)
     DV = slice(43, None)
 
-    def __init__(self, chave=False, codigo_uf=False, ano_mes=False, cnpj_emitente=False, modelo_documento=False,
+    def __init__(self, chave=False, codigo_uf=False, ano_mes=False, cnpj_cpf_emitente=False, modelo_documento=False,
                  numero_serie=False, numero_documento=False, forma_emissao=1, codigo_aleatorio=False, validar=False):
 
         if not chave:
-            if not (codigo_uf and ano_mes and cnpj_emitente and modelo_documento and numero_documento and
+            if not (codigo_uf and ano_mes and cnpj_cpf_emitente and modelo_documento and numero_documento and
                     numero_documento):
                 raise ValueError('Impossível gerar a chave!!')
 
@@ -77,7 +111,7 @@ class ChaveEdoc(object):
 
             campos += ano_mes
 
-            campos += str(punctuation_rm(cnpj_emitente)).zfill(self.CNPJ.stop - self.CNPJ.start)
+            campos += str(punctuation_rm(cnpj_cpf_emitente)).zfill(self.CNPJ_CPF.stop - self.CNPJ_CPF.start)
             campos += str(modelo_documento).zfill(self.MODELO.stop - self.MODELO.start)
             campos += str(numero_serie).zfill(self.SERIE.stop - self.SERIE.start)
             campos += str(numero_documento).zfill(self.NUMERO.stop - self.NUMERO.start)
@@ -131,29 +165,88 @@ class ChaveEdoc(object):
         return codigo
 
     def validar(self):
+        """Validação da chave do documento fiscal
+
+
+        cUF
+
+        MODELO
+
+        SERIE
+
+        |Emit     |Processo Emissão       |Série   |Ch Acesso
+        |CNPJ     |Aplicativo da Empresa  |000-889 |CNPJ do Emitente
+        |CNPJ     |Programa Emissor Fisco |000-889 |CNPJ do Emitente
+        |CNPJ/CPF |Site SEFAZ (NFA-e)     |890-899 |CNPJ da SEFAZ
+        |CNPJ     |Site SEFAZ             |900-909 |CNPJ do Emitente
+        |CPF      |Site SEFAZ             |910-919 |CPF do Emitente
+        |CPF      |Aplicativo da Empresa  |920-969 |CPF do Emitente
+
+        """
+
+        # Verifica se o valor do campo CUF é válido
+        # O valor deve ser o código do IBGE da UF
+        if int(self.campos[ChaveEdoc.CUF]) not in CODIGO_ESTADOS_IBGE:
+            raise ValueError(
+                ('Chave de acesso invalida (codigo UF: {!r}): {!r}').format(
+                    self.campos[ChaveEdoc.CUF], self.chave
+                )
+            )
+
+        # Verifica se o valor do campo MODELO é válido
+        if self.campos[ChaveEdoc.MODELO] not in CODIGO_MODELOS_EDOC:
+            raise ValueError((
+                'Chave de acesso invalida '
+                '(Modelos não permitidos: {!r}): {!r}'
+                ).format(self.campos[ChaveEdoc.MODELO], self.chave))
+
+        # Verifica se o valor do campo Série é válido
+        series_cnpj = list(range(0, 889 + 1)) + list(range(900, 909 + 1))
+        series_cnpj_cpf = list(range(890, 899 + 1))
+        series_cpf = list(range(910, 969 + 1))
+        series_geral = series_cnpj + series_cnpj_cpf + series_cpf
+
+        serie_number = int(self.campos[ChaveEdoc.SERIE])
+        if serie_number not in series_geral:
+            raise ValueError((
+                    'Chave de acesso invalida '
+                    '(Série: {!r}): {!r}'
+                ).format(self.campos[ChaveEdoc.SERIE], self.chave))
+
+        # Por padrão o documento do emitente é o CNPJ
+        doc_emitente = ["CNPJ", self.campos[ChaveEdoc.CNPJ_CPF]]
+
+        # Caso a série esteja entre 920 a 969, o documento do emitente
+        # deve ser CPF
+        # Caso a série esteja entre 890 e 899 o documento do emitente
+        # pode ser CPF ou CNPJ
+        if (
+                (serie_number in series_cpf) or
+                (
+                    serie_number in series_cnpj_cpf
+                    and not cnpj_cpf.validar(self.campos[ChaveEdoc.CNPJ_CPF])
+                )
+        ):
+            doc_emitente = ["CPF", self.campos[ChaveEdoc.CNPJ_CPF][3:]]
+
+        if not cnpj_cpf.validar(doc_emitente[1]):
+            raise ValueError(
+                (
+                    'Chave de acesso invalida '
+                    '({!r} emitente: {!r}): {!r}'
+                ).format(
+                    doc_emitente[0],
+                    cnpj_cpf.formata(doc_emitente[1]),
+                    self.chave
+                )
+            )
+
         digito = modulo11(self.campos[:43])
         if not (digito == int(self.campos[-1])):
             raise ValueError((
                     'Digito verificador invalido: '
                     'chave={!r}, digito calculado={!r}'
                 ).format(self.chave, digito))
-
-        # if not br.is_codigo_uf(int(self.campos[ChaveEdoc.CUF])):
-        #     raise ValueError((
-        #             'Chave de acesso invalida (codigo UF: {!r}): {!r}'
-        #         ).format(self.campos[ChaveEdoc.CUF], chave))
-
-        if self.campos[ChaveEdoc.MODELO] not in ('55', '57', '58', '59', '65'):
-            raise ValueError((
-                'Chave de acesso invalida '
-                '(Modelos não permitidos: {!r}): {!r}'
-                ).format(self.campos[ChaveEdoc.MODELO], self.chave))
-
-        if not cnpj_cpf.validar(self.campos[ChaveEdoc.CNPJ]):
-            raise ValueError((
-                    'Chave de acesso invalida '
-                    '(CNPJ emitente: {!r}): {!r}'
-                ).format(self.campos[ChaveEdoc.CNPJ], self.chave))
 
     def __str__(self):
         return self.chaveMOD
@@ -206,8 +299,8 @@ class ChaveEdoc(object):
         return int(self._campos[self.AAMM][2:])
 
     @property
-    def cnpj_emitente(self):
-        return cnpj_cpf.formata(self._campos[self.CNPJ])
+    def cnpj_cpf_emitente(self):
+        return cnpj_cpf.formata(self._campos[self.CNPJ_CPF])
 
     @property
     def modelo_documento(self):

--- a/tests/test_chave_edoc.py
+++ b/tests/test_chave_edoc.py
@@ -22,7 +22,7 @@ class Tests(TestCase):
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
-        self.assertEqual(edoc_1.cnpj_emitente, cnpj, 'Key: cnpj_emitente failed')
+        self.assertEqual(edoc_1.cnpj_cpf_emitente, cnpj, 'Key: cnpj_cpf_emitente failed')
         self.assertEqual(edoc_1.codigo_uf, codigo_uf, 'Key: codigo_uf failed')
         self.assertEqual(edoc_1.forma_emissao, forma_emissao, 'Key: forma_emissao failed')
         self.assertEqual(edoc_1.modelo_documento, modelo_documento, 'Key: modelo_documento failed')
@@ -36,7 +36,7 @@ class Tests(TestCase):
 
         edoc_2 = ChaveEdoc(
             ano_mes=ano_mes,
-            cnpj_emitente=cnpj,
+            cnpj_cpf_emitente=cnpj,
             codigo_uf=codigo_uf,
             forma_emissao=forma_emissao,
             modelo_documento=modelo_documento,
@@ -66,7 +66,7 @@ class Tests(TestCase):
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
-        self.assertEqual(edoc_1.cnpj_emitente, cnpj, 'Key: cnpj_emitente failed')
+        self.assertEqual(edoc_1.cnpj_cpf_emitente, cnpj, 'Key: cnpj_cpf_emitente failed')
         self.assertEqual(edoc_1.codigo_uf, codigo_uf, 'Key: codigo_uf failed')
         self.assertEqual(edoc_1.forma_emissao, forma_emissao, 'Key: forma_emissao failed')
         self.assertEqual(edoc_1.modelo_documento, modelo_documento, 'Key: modelo_documento failed')
@@ -80,7 +80,7 @@ class Tests(TestCase):
 
         edoc_2 = ChaveEdoc(
             ano_mes=ano_mes,
-            cnpj_emitente=cnpj,
+            cnpj_cpf_emitente=cnpj,
             codigo_uf=codigo_uf,
             forma_emissao=forma_emissao,
             modelo_documento=modelo_documento,
@@ -110,7 +110,7 @@ class Tests(TestCase):
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
-        self.assertEqual(edoc_1.cnpj_emitente, cnpj, 'Key: cnpj_emitente failed')
+        self.assertEqual(edoc_1.cnpj_cpf_emitente, cnpj, 'Key: cnpj_cpf_emitente failed')
         self.assertEqual(edoc_1.codigo_uf, codigo_uf, 'Key: codigo_uf failed')
         self.assertEqual(edoc_1.forma_emissao, forma_emissao, 'Key: forma_emissao failed')
         self.assertEqual(edoc_1.modelo_documento, modelo_documento, 'Key: modelo_documento failed')
@@ -124,7 +124,7 @@ class Tests(TestCase):
 
         edoc_2 = ChaveEdoc(
             ano_mes=ano_mes,
-            cnpj_emitente=cnpj,
+            cnpj_cpf_emitente=cnpj,
             codigo_uf=codigo_uf,
             forma_emissao=forma_emissao,
             modelo_documento=modelo_documento,
@@ -154,7 +154,7 @@ class Tests(TestCase):
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
-        self.assertEqual(edoc_1.cnpj_emitente, cnpj, 'Key: cnpj_emitente failed')
+        self.assertEqual(edoc_1.cnpj_cpf_emitente, cnpj, 'Key: cnpj_cpf_emitente failed')
         self.assertEqual(edoc_1.codigo_uf, codigo_uf, 'Key: codigo_uf failed')
         self.assertEqual(edoc_1.forma_emissao, forma_emissao, 'Key: forma_emissao failed')
         self.assertEqual(edoc_1.modelo_documento, modelo_documento, 'Key: modelo_documento failed')
@@ -168,7 +168,7 @@ class Tests(TestCase):
 
         edoc_2 = ChaveEdoc(
             ano_mes=ano_mes,
-            cnpj_emitente=cnpj,
+            cnpj_cpf_emitente=cnpj,
             codigo_uf=codigo_uf,
             forma_emissao=forma_emissao,
             modelo_documento=modelo_documento,
@@ -198,7 +198,7 @@ class Tests(TestCase):
         edoc_1 = ChaveEdoc(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
-        self.assertEqual(edoc_1.cnpj_emitente, cnpj, 'Key: cnpj_emitente failed')
+        self.assertEqual(edoc_1.cnpj_cpf_emitente, cnpj, 'Key: cnpj_cpf_emitente failed')
         self.assertEqual(edoc_1.codigo_uf, codigo_uf, 'Key: codigo_uf failed')
         self.assertEqual(edoc_1.forma_emissao, forma_emissao, 'Key: forma_emissao failed')
         self.assertEqual(edoc_1.modelo_documento, modelo_documento, 'Key: modelo_documento failed')
@@ -212,7 +212,7 @@ class Tests(TestCase):
 
         edoc_2 = ChaveEdoc(
             ano_mes=ano_mes,
-            cnpj_emitente=cnpj,
+            cnpj_cpf_emitente=cnpj,
             codigo_uf=codigo_uf,
             forma_emissao=forma_emissao,
             modelo_documento=modelo_documento,
@@ -243,7 +243,7 @@ class Tests(TestCase):
         edoc_1 = ChaveCFeSAT(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
-        self.assertEqual(edoc_1.cnpj_emitente, cnpj, 'Key: cnpj_emitente failed')
+        self.assertEqual(edoc_1.cnpj_cpf_emitente, cnpj, 'Key: cnpj_cpf_emitente failed')
         self.assertEqual(edoc_1.codigo_uf, codigo_uf, 'Key: codigo_uf failed')
         self.assertEqual(edoc_1.forma_emissao, forma_emissao, 'Key: forma_emissao failed')
         self.assertEqual(edoc_1.modelo_documento, modelo_documento, 'Key: modelo_documento failed')
@@ -276,7 +276,7 @@ class Tests(TestCase):
         edoc_1 = ChaveCFeSAT(chave=chave)
 
         self.assertEqual(edoc_1.ano_mes, ano_mes, 'Key: ano_mes failed')
-        self.assertEqual(edoc_1.cnpj_emitente, cnpj, 'Key: cnpj_emitente failed')
+        self.assertEqual(edoc_1.cnpj_cpf_emitente, cnpj, 'Key: cnpj_cpf_emitente failed')
         self.assertEqual(edoc_1.codigo_uf, codigo_uf, 'Key: codigo_uf failed')
         self.assertEqual(edoc_1.forma_emissao, forma_emissao, 'Key: forma_emissao failed')
         self.assertEqual(edoc_1.modelo_documento, modelo_documento, 'Key: modelo_documento failed')
@@ -308,6 +308,11 @@ class Tests(TestCase):
             '35210320695448000184540010000035891981839924',
             # NFE em maiusculo
             '35210320695448000184540010000035891981839924',
+            # UF Inválida
+            '99150808723218000186599000040190000241114257',
+            # Chave com série de CNPJ mas com CPF emitente
+            '42221200050690671849558890000000811540256167',
+
         ]
         for chave in chaves_invalidas:
             with self.assertRaises(ValueError):
@@ -321,7 +326,8 @@ class Tests(TestCase):
             '35210320695448000184550010000035891981839923',
             '32171232438772000104570010001990751153183825',
             '35150808723218000186599000040190000241114257',
-            '35150808723218000186599000040190000557255950'
+            '35150808723218000186599000040190000557255950',
+            '42221200050690671849559100000000811540256167',
         ]
         for chave in chaves_validas:
             edoc = detectar_chave_edoc(chave=chave)


### PR DESCRIPTION
Melhorias na validação da chave dos documentos fiscais, de acordo com a NT 2018-001, foi reservado alguns intervalos de series, com finalidade de identificar o emitente e o assinante do documento

![image](https://user-images.githubusercontent.com/211005/210637214-247ab6ba-fabb-4f40-a57d-26e770bd67b4.png)

Neste PR eu implemento:

- [x] Validação de series;
- [x] Validação do CNPJ ou CPF do emitente;
- [x] Validação do código da UF. 