### PR TITLE
[FIX] Inscrição Estadual de Minas Gerais pode ser menor que 13.

### DIFF
--- a/src/erpbrasil/base/fiscal/ie.py
+++ b/src/erpbrasil/base/fiscal/ie.py
@@ -300,13 +300,15 @@ def validar_mg(inscr_est):
     inscr_est = re.sub("[^0-9]", "", inscr_est)
 
     # verificando o tamanho da inscrição estadual
-    if len(inscr_est) != 13:
+    if len(inscr_est) not in [13, 11]:
         return False
 
     # Pega apenas os 11 primeiros dígitos da inscrição estadual e
     # gera os dígitos verificadores
     inscr_est = list(map(int, inscr_est))
     nova_ie = inscr_est[:11]
+    if len(inscr_est) == 11:
+        nova_ie = inscr_est
 
     nova_ie_aux = list(nova_ie)
     nova_ie_aux.insert(3, 0)


### PR DESCRIPTION
Inscrição Estadual de Minas Gerais pode ser menor que 13, mas diferente do PR https://github.com/erpbrasil/erpbrasil.base/pull/44 aqui não tenho certeza se a forma que alterei o código está correta ou é a melhor solução por isso um debate e avaliação é necessário, porque a recomendação nesses casos é preencher com Zeros a  Esquerda, mas para o usuário isso não fica claro já que mensagem retornada é apenas "Inscrição Estadual Inválida" e se ele consultar em algum site da SEFAZ retorna que o IE é válido o que acaba gerando a impressão e a reclamação "Existe um erro no programa", exemplo:

https://dfe-portal.svrs.rs.gov.br/NFE/CCC
![image](https://github.com/erpbrasil/erpbrasil.base/assets/6341149/10309239-bbf7-4d06-abbf-c4a706a72fc2)


Possíveis soluções:
* o que foi feito aqui nesse PR apenas permitir esse caso
* Retornar uma mensagem mais clara para o usuário sobre preencher com Zeros a Esquerda até o tamanho 13
* Preencher com Zeros no momento da validação
* Alguma outra possibilidade?

Uma questão que surgiu vendo isso hoje na Localização o método que Formata o IE https://github.com/erpbrasil/erpbrasil.base/blob/master/src/erpbrasil/base/fiscal/ie.py#L534  não está sendo usado, deveria?

l10n-brazil-oca$ grep -rn 'formata(' --include=\*.py . --color=always
./l10n_br_crm/models/crm_lead.py:94:        self.cnpj = cnpj_cpf.formata(self.cnpj)
./l10n_br_crm/models/crm_lead.py:98:        self.cpf = cnpj_cpf.formata(self.cpf)
./l10n_br_nfe/models/res_partner.py:251:                rec.cnpj_cpf = cnpj_cpf.formata(str(rec.nfe40_CNPJ))
./l10n_br_nfe/models/res_partner.py:265:                rec.cnpj_cpf = cnpj_cpf.formata(str(rec.nfe40_CPF))
./l10n_br_nfe/models/res_partner.py:298:                ("cnpj_cpf", "=", cnpj_cpf.formata(rec_dict["cnpj_cpf"])),
./l10n_br_nfe/models/document.py:1138:        if edoc_type == "in" and document.company_id.cnpj_cpf != cnpj_cpf.formata(
./l10n_br_pos/models/res_partner.py:16:            partner["cnpj_cpf"] = cnpj_cpf.formata(partner["vat"])
./l10n_br_pos/models/res_partner.py:19:            partner["cnpj_cpf"] = cnpj_cpf.formata(partner["vat"])
./l10n_br_hr/models/hr_employee.py:246:        cpf = cnpj_cpf.formata(str(self.cpf))
./l10n_br_hr/models/hr_employee_dependent.py:79:        cpf = cnpj_cpf.formata(str(self.cnpj_cpf))
./l10n_br_base/models/party_mixin.py:66:        self.cnpj_cpf = cnpj_cpf.formata(str(self.cnpj_cpf))
./l10n_br_fiscal/models/document_related.py:133:        self.cnpj_cpf = cnpj_cpf.formata(str(self.cnpj_cpf))


cc @renatonlima @rvalyi @marcelsavegnago @mileo 