### PR TITLE
[UPD+FIX] Atualizando as bibliotecas do Pre-commit e corrigido conflito entre validações 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,20 +5,20 @@
 exclude: '^(\.tox|ci/templates|\.bumpversion\.cfg)(/|$)'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.12.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8

--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,6 @@ Overview
     :target: https://readthedocs.org/projects/erpbrasilbase
     :alt: Documentation Status
 
-.. |travis| image:: https://api.travis-ci.org/erpbrasil/erpbrasil.base.svg?branch=master
-    :alt: Travis-CI Build Status
-    :target: https://travis-ci.org/erpbrasil/erpbrasil.base
-
 .. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/erpbrasil/erpbrasil.base?branch=master&svg=true
     :alt: AppVeyor Build Status
     :target: https://ci.appveyor.com/project/erpbrasil/erpbrasil.base

--- a/ci/bootstrap.py
+++ b/ci/bootstrap.py
@@ -35,7 +35,7 @@ def exec_in_env():
         check_call([bin_path / "pip", "install", "jinja2", "tox"])
     python_executable = bin_path / "python"
     if not python_executable.exists():
-        python_executable = python_executable.with_suffix('.exe')
+        python_executable = python_executable.with_suffix(".exe")
 
     print("Re-executing with: {0}".format(python_executable))
     print("+ exec", python_executable, __file__, "--no-env")
@@ -61,16 +61,22 @@ def main():
         # This uses sys.executable the same way that the call in
         # cookiecutter-pylibrary/hooks/post_gen_project.py
         # invokes this bootstrap.py itself.
-        for line in subprocess.check_output([sys.executable, '-m', 'tox', '--listenvs'], universal_newlines=True).splitlines()
+        for line in subprocess.check_output(
+            [sys.executable, "-m", "tox", "--listenvs"], universal_newlines=True
+        ).splitlines()
     ]
-    tox_environments = [line for line in tox_environments if line.startswith('py')]
+    tox_environments = [line for line in tox_environments if line.startswith("py")]
 
-    for template in templates_path.rglob('*'):
+    for template in templates_path.rglob("*"):
         if template.is_file():
             template_path = str(template.relative_to(templates_path))
             destination = base_path / template_path
             destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_text(jinja.get_template(template_path).render(tox_environments=tox_environments))
+            destination.write_text(
+                jinja.get_template(template_path).render(
+                    tox_environments=tox_environments
+                )
+            )
             print("Wrote {}".format(template_path))
     print("DONE.")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ universal = 1
 [flake8]
 max-line-length = 140
 exclude = */migrations/*
+# Conflito entre o Black e Flake8
+# https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#slices
+# This behaviour may raise E203 whitespace before ':' warnings in style guide enforcement tools like Flake8. Since E203 is not PEP 8 compliant, you should tell Flake8 to ignore these warnings.
+extend-ignore = E203
 
 [tool:pytest]
 testpaths = tests

--- a/src/erpbrasil/base/fiscal/edoc.py
+++ b/src/erpbrasil/base/fiscal/edoc.py
@@ -347,7 +347,7 @@ class ChaveEdoc(object):
         ).format(num_partes)
 
         salto = 44 // num_partes
-        return [self._campos[n: (n + salto)] for n in range(0, 44, salto)]
+        return [self._campos[n : (n + salto)] for n in range(0, 44, salto)]
 
 
 class ChaveCFeSAT(ChaveEdoc):

--- a/src/erpbrasil/base/gs1/gtin.py
+++ b/src/erpbrasil/base/gs1/gtin.py
@@ -15,7 +15,7 @@ def calcula_dv(gs1_code, code_length):
     prod = [3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3]
 
     # get the product with some gs1_code length
-    gs1_prod = prod[len(prod) - len(gs1_code):]
+    gs1_prod = prod[len(prod) - len(gs1_code) :]
 
     while len(gs1_code) < code_length:
         r = sum([x * y for (x, y) in zip(gs1_code, gs1_prod)]) % 10


### PR DESCRIPTION
Ao verificar o problema dos PRs https://github.com/erpbrasil/erpbrasil.base/pull/44 e https://github.com/erpbrasil/erpbrasil.base/pull/45 acabei rodando o comando do pre-commit localmente para manter o padrão do código, acabei vendo que estava retornando um erro E203 e procurei atualizar as bibliotecas para ver se resolvia, mas na verdade existe um conflito entre as bibliotecas Black e Flake8 

https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#slices

This behaviour may raise E203 whitespace before ':' warnings in style guide enforcement tools like Flake8. Since E203 is not PEP 8 compliant, you should tell Flake8 to ignore these warnings.

https://www.flake8rules.com/rules/E203.html

https://flake8.pycqa.org/en/3.1.1/user/ignoring-errors.html

Então nesse PR estou atualizando as Libs, corrigindo esse conflito e ao rodar o comando pre-commit acaba refatorando algumas partes do código, com isso o pre-commit passou a rodar sem erros pelo menos localmente, é preciso verificar se vai precisar mais alterações aqui no github.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 