### PR TITLE
feat: Add support for alphanumeric CNPJ

### DIFF
--- a/src/erpbrasil/base/fiscal/cnpj_cpf.py
+++ b/src/erpbrasil/base/fiscal/cnpj_cpf.py
@@ -5,6 +5,16 @@
 import re
 
 
+def _get_char_value(char):
+    """
+    Returns the integer value of a character for CNPJ calculation.
+    'A' = 17, 'B' = 18, ..., and numbers are their own value.
+    """
+    if '0' <= char <= '9':
+        return int(char)
+    return ord(char.upper()) - 48
+
+
 def validar(cnpj_cpf=None):
     """Função básica para validação de um CNPJ ou CPF depedendo da
     quantidade de digitos (sem acentuação), caso a string tenha 14 digitos
@@ -15,13 +25,16 @@ def validar(cnpj_cpf=None):
     """
     if not cnpj_cpf:
         return
-    cnpj_cpf = re.sub("[^0-9]", "", cnpj_cpf)
+    cnpj_cpf = re.sub("[^0-9A-Z]", "", str(cnpj_cpf).upper())
 
     if len(cnpj_cpf) == 14:
         return validar_cnpj(cnpj_cpf)
 
     if len(cnpj_cpf) == 11:
-        return validar_cpf(cnpj_cpf)
+        # Prevent alphanumeric CPF validation
+        if cnpj_cpf.isdigit():
+            return validar_cpf(cnpj_cpf)
+        return False
 
 
 def validar_cnpj(cnpj):
@@ -31,16 +44,19 @@ def validar_cnpj(cnpj):
     :return bool: True or False
     """
     # Limpando o cnpj
-    if not cnpj.isdigit():
-        cnpj = re.sub("[^0-9]", "", cnpj)
+    cnpj = re.sub("[^0-9A-Z]", "", str(cnpj).upper())
 
     # verificando o tamano do  cnpj
     if len(cnpj) != 14:
         return False
 
+    # The last two digits (check digits) must be numeric
+    if not cnpj[-2:].isdigit():
+        return False
+
     # Pega apenas os 12 primeiros dígitos do CNPJ e gera os digitos
-    cnpj = list(map(int, cnpj))
-    novo = cnpj[:12]
+    cnpj_values = [_get_char_value(c) for c in cnpj]
+    novo = cnpj_values[:12]
 
     prod = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
     while len(novo) < 14:
@@ -53,7 +69,7 @@ def validar_cnpj(cnpj):
         prod.insert(0, 6)
 
     # Se o número gerado coincidir com o número original, é válido
-    if novo == cnpj:
+    if novo == cnpj_values:
         return True
 
     return False
@@ -67,15 +83,14 @@ def validar_cpf(cpf):
       - 'cpf': CPF to be validate.
     """
     # Limpando o cpf
-    if not cpf.isdigit():
-        cpf = re.sub("[^0-9]", "", cpf)
+    cpf = re.sub("[^0-9]", "", str(cpf))
 
     if len(cpf) != 11 or cpf == cpf[0] * len(cpf):
         return False
 
     # Pega apenas os 9 primeiros dígitos do CPF e gera os 2 dígitos que faltam
-    cpf = list(map(int, cpf))
-    novo = cpf[:9]
+    cpf_values = list(map(int, cpf))
+    novo = cpf_values[:9]
 
     while len(novo) < 11:
         r = sum([(len(novo) + 1 - i) * v for i, v in enumerate(novo)]) % 11
@@ -87,7 +102,7 @@ def validar_cpf(cpf):
         novo.append(f)
 
     # Se o número gerado coincidir com o número original, é válido
-    if novo == cpf:
+    if novo == cpf_values:
         return True
     return False
 
@@ -95,18 +110,18 @@ def validar_cpf(cpf):
 def formata(cnpj_cpf=None):
     if not cnpj_cpf:
         return
-    cnpj_cpf = re.sub("[^0-9]", "", cnpj_cpf)
+    cnpj_cpf = re.sub("[^0-9A-Z]", "", str(cnpj_cpf).upper())
     if len(cnpj_cpf) == 14:
         cnpj_cpf = formata_cnpj(cnpj_cpf)
 
-    if len(cnpj_cpf) == 11:
+    if len(cnpj_cpf) == 11 and cnpj_cpf.isdigit():
         cnpj_cpf = formata_cpf(cnpj_cpf)
 
     return cnpj_cpf
 
 
 def formata_cnpj(cnpj=None):
-    cnpj = re.sub("[^0-9]", "", cnpj)
+    cnpj = re.sub("[^0-9A-Z]", "", str(cnpj).upper())
     if len(cnpj) == 14:
         cnpj = "%s.%s.%s/%s-%s" % (
             cnpj[0:2],
@@ -120,7 +135,7 @@ def formata_cnpj(cnpj=None):
 
 
 def formata_cpf(cpf=None):
-    cpf = re.sub("[^0-9]", "", cpf)
+    cpf = re.sub("[^0-9]", "", str(cpf))
     if len(cpf) == 11:
         cpf = "%s.%s.%s-%s" % (cpf[0:3], cpf[3:6], cpf[6:9], cpf[9:11])
 

--- a/tests/test_tools_fiscal.py
+++ b/tests/test_tools_fiscal.py
@@ -65,3 +65,25 @@ class Tests(TestCase):
     def test_01_formata_cpf(self):
         """Teste formatação de CPF correto"""
         self.assertEqual(cnpj_cpf.formata_cpf("06853187024"), "068.531.870-24")
+
+    def test_01_validar_cnpj_alfanumerico(self):
+        """Teste validação de CNPJ alfanumérico correto"""
+        self.assertTrue(cnpj_cpf.validar("AKRETION123401"))
+
+    def test_02_validar_cnpj_alfanumerico(self):
+        """Teste validação de CNPJ alfanumérico incorreto"""
+        self.assertFalse(cnpj_cpf.validar("AKRETION123402"))
+
+    def test_03_validar_cnpj_alfanumerico_dv_invalido(self):
+        """Teste validação de CNPJ alfanumérico com DV inválido"""
+        self.assertFalse(cnpj_cpf.validar("AKRETION12340A"))
+
+    def test_04_validar_cnpj_alfanumerico_caracter_invalido(self):
+        """Teste validação de CNPJ alfanumérico com caracter inválido"""
+        self.assertFalse(cnpj_cpf.validar("AKRETION123!01"))
+
+    def test_01_formata_cnpj_alfanumerico(self):
+        """Teste formatação de CNPJ alfanumérico correto"""
+        self.assertEqual(
+            cnpj_cpf.formata("AKRETION123401"), "AK.RET.ION/1234-01"
+        )


### PR DESCRIPTION
This commit introduces support for alphanumeric CNPJs, which are planned to be introduced in Brazil in 2026.

The changes include:
- A new helper function `_get_char_value` to convert alphanumeric characters to their corresponding integer values for the validation algorithm.
- Updated `validar_cnpj` and `formata_cnpj` to correctly handle alphanumeric characters.
- Added new unit tests to verify the validation and formatting of alphanumeric CNPJs.