### PR TITLE
feat(fiscal): Allow 'ISENTO' as a valid IE

### DIFF
--- a/src/erpbrasil/base/fiscal/ie.py
+++ b/src/erpbrasil/base/fiscal/ie.py
@@ -102,6 +102,8 @@ PARAMETERS = {
 
 
 def validar(uf, inscr_est):
+    if inscr_est.upper() == "ISENTO":
+        return True
     result = True
     try:
         validar_by_uf = globals()["validar_%s" % uf]

--- a/tests/test_fiscal_ie_validar.py
+++ b/tests/test_fiscal_ie_validar.py
@@ -409,6 +409,14 @@ class ValidarIETest(TestCase):
                     "Erro a validar inscrição estadual para a UF: %s" % uf,
                 )
 
+    def test_ie_isentas(self):
+        """Testa a validação de IEs Isentas"""
+        for uf in ie_validas:
+            self.assertTrue(
+                ie.validar(uf, "ISENTO"),
+                "Erro a validar inscrição estadual para a UF: %s" % uf,
+            )
+
     def test_ie_validas(self):
         """Testa a validação de IEs válidas"""
         for uf in ie_validas:


### PR DESCRIPTION
The `validar` function in `erpbrasil.base.fiscal.ie` now returns `True` when the `inscr_est` is 'ISENTO', regardless of the state. This is necessary to handle cases where the entity is exempt from state registration.

A new test case has been added to verify this behavior.