### PR TITLE
add temporary workaround for publish ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,3 +36,6 @@ jobs:
         .
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # Temporary workaround for https://github.com/pypa/gh-action-pypi-publish/issues/283
+        attestations: false


### PR DESCRIPTION
Solução temporaria para corrigir erro na publicação do pypi
Temporary workaround for https://github.com/pypa/gh-action-pypi-publish/issues/283