### PR TITLE
[REF] Implementação do CNPJ Alfanumérico (NT 2025.001)

### DIFF
--- a/docs/cnpj.rst
+++ b/docs/cnpj.rst
@@ -1,0 +1,327 @@
+================================
+CNPJ Alfanumérico (NT 2025.001)
+================================
+
+Introdução
+==========
+
+A Receita Federal do Brasil publicou a Instrução Normativa 2229 de 15 de outubro de 2024
+que modifica a regra de formação do CNPJ no Brasil. Essa ação visa ampliar a capacidade
+de geração de números de CNPJ para abertura de empresas devido ao esgotamento da
+modelagem atual.
+
+A previsão de geração dos primeiros CNPJ Alfanuméricos está definida para **julho de 2026**.
+
+Esta nota técnica abrange os ambientes de autorização de documentos fiscais eletrônicos
+sob a coordenação do ENCAT:
+
+* NF-e
+* NFC-e
+* CT-e
+* CT-e OS
+* GTVe
+* MDF-e
+* BP-e
+* BP-e TM
+* NF3e
+* NFCom
+
+**Cronograma de implantação:**
+
++----------+-------------------------------+----------------------------+----------------------+
+| Versão   | Histórico                     | Implantação Homologação    | Implantação Produção |
++==========+===============================+============================+======================+
+| 1.00     | Versão inicial da NT Conjunta | 06/04/2026                 | 06/07/2026           |
++----------+-------------------------------+----------------------------+----------------------+
+
+Nova Lei de Formação do CNPJ
+=============================
+
+O novo número de identificação — **CNPJ Alfanumérico** — terá o mesmo tamanho que o
+número atual, com **14 posições**, distribuídas da seguinte forma:
+
++-------------------+--------------------+-------------------+
+| Raiz (8 posições) | Ordem (4 posições) | DV (2 posições)   |
++===================+====================+===================+
+| Alfanumérica      | Alfanumérica       | Numérica          |
++-------------------+--------------------+-------------------+
+
+* As **oito primeiras posições** (raiz) terão caracteres alfanuméricos (letras e números).
+* As **quatro posições seguintes** (ordem do estabelecimento) também terão caracteres
+  alfanuméricos.
+* As **duas últimas posições** são numéricas e identificam os dígitos verificadores.
+
+Cálculo do Dígito Verificador do CNPJ Alfanumérico
+----------------------------------------------------
+
+A fórmula de cálculo do dígito verificador **não muda**: continua sendo pelo **módulo 11**.
+Porém, para garantir compatibilidade com CNPJs puramente numéricos existentes, altera-se
+o modo de obtenção dos valores usados no cálculo:
+
+* Cada caractere (numérico ou alfabético) é substituído pelo valor decimal correspondente
+  ao seu código ASCII menos 48.
+* Desta forma, os dígitos numéricos mantêm os mesmos valores (``'0'`` → 0, ``'9'`` → 9).
+* As letras assumem os valores: ``A`` = 17, ``B`` = 18, ``C`` = 19 … e assim por diante.
+
+Pesos utilizados no cálculo (posições 1 a 13, da esquerda para a direita)::
+
+    Posição: 1  2  3  4  5  6  7  8  9  10 11 12 13
+    Peso DV1: 5  4  3  2  9  8  7  6  5  4  3  2  -
+    Peso DV2: 6  5  4  3  2  9  8  7  6  5  4  3  2
+
+Algoritmo (módulo 11):
+
+1. Para cada um dos 12 primeiros caracteres (sem os DVs), calcule ``valor_ascii - 48``.
+2. Multiplique pelo peso correspondente e some os resultados → ``soma_dv1``.
+3. ``dv1 = 0`` se ``soma_dv1 % 11 < 2``, senão ``dv1 = 11 - (soma_dv1 % 11)``.
+4. Repita o processo incluindo ``dv1`` com peso 2 → ``soma_dv2``.
+5. ``dv2 = 0`` se ``soma_dv2 % 11 < 2``, senão ``dv2 = 11 - (soma_dv2 % 11)``.
+
+Letras não permitidas
+---------------------
+
+Algumas letras **não devem ser aceitas** no CNPJ Alfa por solicitação do ENCAT à
+Receita Federal:
+
+* ``I`` (letra i maiúscula)
+* ``O`` (letra o maiúscula)
+* ``U`` (letra u maiúscula)
+* ``Q`` (letra q maiúscula)
+* ``F`` (letra f maiúscula)
+
+.. note::
+   Esta exclusão faz parte das solicitações feitas pela equipe técnica do ENCAT para a
+   Receita Federal do Brasil e precisa ser confirmada em versão posterior da nota técnica.
+
+Campos do Tipo CNPJ nos DFe
+============================
+
+A expressão regular que valida um campo do tipo CNPJ nos schemas XSD passa a aceitar
+letras maiúsculas nas primeiras 12 posições::
+
+    [A-Z0-9]{12}[0-9]{2}
+
+Os campos que representam um CNPJ existem dispostos diversas vezes em todos os DFe,
+eventos e schemas de serviços disponíveis (emitente, destinatário, tomador, comprador,
+recebedor, expedidor, etc.).
+
+Regras de Validação
+-------------------
+
+A redação das regras de validação existentes **não se altera**: elas continuam indicando
+que o CNPJ informado deve ser válido em relação ao DV.
+
+A partir da data de implantação, os ambientes autorizadores considerarão o novo cálculo
+de DV tanto para CNPJs numéricos quanto alfanuméricos. As rejeições já existentes
+continuarão sendo aplicadas.
+
+.. important::
+   As rotinas de validação de CNPJ devem rejeitar CNPJ Alfanuméricos informados
+   **anteriores à data de implantação** de cada ambiente (homologação e produção),
+   mesmo que seja admitida a informação na validação de schema. A rejeição aplicada
+   nesse caso será a de falha no cálculo do dígito verificador.
+
+Chave de Acesso com CNPJ Alfanumérico
+======================================
+
+A chave de acesso de qualquer DFe possui estrutura de 44 posições, sendo que as posições
+do CNPJ (posições 7 a 20) podem agora conter caracteres alfanuméricos:
+
++--------+---------+------------------+-------+-------+--------+--------+---------+----+
+| cUF    | AAMM    | CNPJ Emitente    | mod   | serie | nNF    | tpEmis | cXXX    | cDV|
++========+=========+==================+=======+=======+========+========+=========+====+
+| 2 dig. | 4 dig.  | 14 dig. (alfa)   | 2 dig | 3 dig | 9 dig. | 1 dig. | 8 dig.  | 1  |
++--------+---------+------------------+-------+-------+--------+--------+---------+----+
+
+A expressão regular que verifica a chave de acesso passa a suportar letras nas 12
+primeiras posições do CNPJ::
+
+    [0-9]{6}[A-Z0-9]{12}[0-9]{26}
+
+.. note::
+   Se algumas letras forem vedadas na composição do CNPJ Alfa, isso deve ser considerado
+   também para a chave de acesso.
+
+Cálculo do DV da Chave de Acesso
+----------------------------------
+
+O cálculo do DV da chave de acesso aplica a **mesma lógica do CNPJ Alfa**:
+
+1. Substituir cada um dos 44 caracteres pelo valor ``código_ASCII - 48``.
+2. Aplicar o cálculo do **módulo 11** sobre a totalidade dos dígitos resultantes
+   (mesma lógica já utilizada para chaves puramente numéricas).
+
+.. important::
+   As rotinas de validação de chave de acesso devem rejeitar chaves contendo CNPJ
+   Alfanuméricos informados **anteriores à data de implantação** de cada ambiente.
+   A rejeição aplicada será a de falha no CNPJ informado na chave de acesso.
+
+Código de Barras dos Documentos Auxiliares
+==========================================
+
+O padrão de código de barras impresso no documento auxiliar (DACTE, DANFE, DABPE, etc.)
+é o **CODE-128C**, que suporta somente números. Por isso, ele **não é compatível** com
+chaves de acesso que contenham caracteres alfanuméricos nas posições do CNPJ.
+
+Novo Padrão Híbrido CODE-128A/C
+---------------------------------
+
+Para suportar o CNPJ Alfa, adota-se um **modelo híbrido**:
+
+* **CODE-128C**: codifica pares de dígitos numéricos (00–99), usado nas partes numéricas.
+* **CODE-128A**: aceita números e letras maiúsculas (ASCII 00–95), ativado na ocorrência
+  de caracteres não numéricos.
+* A alternância entre os modos é feita com o código ``100`` (CODE A ↔ CODE C).
+
+Dimensões mínimas
+-----------------
+
++---------------------------------+-------------------------------------+
+| Tipo de impressora              | Largura mínima do código de barras  |
++=================================+=====================================+
+| Não impacto (laser / jato de    | 11,5 cm                             |
+| tinta)                          |                                     |
++---------------------------------+-------------------------------------+
+| Impacto (matricial / de linha)  | 11,5 cm                             |
++---------------------------------+-------------------------------------+
+
+* **Altura mínima da barra:** 0,8 cm
+* **Largura mínima da barra:** 0,02 cm
+
+.. note::
+   Por conta da mudança para o CNPJ Alfa, o novo padrão híbrido (128-A + 128-C) poderá
+   apresentar maior volume de dados para suportar os caracteres não numéricos, exigindo
+   mais espaço para acomodar as barras adicionais.
+
+Cálculo do Dígito Verificador do CODE-128
+------------------------------------------
+
+O DV do código de barras é baseado no **módulo 103**, calculado pela soma ponderada dos
+valores de cada símbolo, incluindo o caractere de início (Start).
+
+* O **Code-128C** usa ``105`` como Start.
+* O **Code-128A** usa ``103`` como Start.
+
+Algoritmo::
+
+    DV = soma_ponderada % 103
+
+Orientações para alternância entre CODE-128C e CODE-128A
+---------------------------------------------------------
+
+1. **Inicie** com o conjunto ``C`` (pois a chave começa com quatro ou mais dígitos).
+2. Se os dados iniciam com número **ímpar** de dígitos: insira ``Code A`` antes do último
+   dígito ímpar.
+3. Se **4 ou mais dígitos** aparecerem em sequência enquanto no modo ``A``:
+
+   * Par de dígitos → insira ``Code C`` antes do primeiro dígito.
+   * Ímpar de dígitos → insira ``Code C`` após o primeiro dígito (o primeiro permanece em ``A``).
+
+4. Quando **no modo C** e um caractere não numérico ocorrer: insira ``Code A`` antes do
+   caractere não numérico.
+
+Exemplo de Validação — CNPJ Alfa (JavaScript)
+=============================================
+
+O exemplo abaixo implementa a validação do CNPJ Alfa conforme a NT 2025.001:
+
+.. code-block:: javascript
+
+   class CNPJ {
+     static tamanhoCNPJSemDV = 12;
+     static regexCNPJSemDV = /^([A-Z\d]){12}$/;
+     static regexCNPJ = /^([A-Z\d]){12}(\d){2}$/;
+     static regexCaracteresMascara = /[./-]/g;
+     static regexCaracteresNaoPermitidos = /[^A-Z\d./-]/i;
+     static valorBase = "0".charCodeAt(0);
+     static pesosDV = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+     static cnpjZerado = "00000000000000";
+
+     static isValid(cnpj) {
+       if (!this.regexCaracteresNaoPermitidos.test(cnpj)) {
+         let cnpjSemMascara = this.removeMascaraCNPJ(cnpj);
+         if (this.regexCNPJ.test(cnpjSemMascara) && cnpjSemMascara !== this.cnpjZerado) {
+           const dvInformado = cnpjSemMascara.substring(this.tamanhoCNPJSemDV);
+           const dvCalculado = this.calculaDV(cnpjSemMascara.substring(0, this.tamanhoCNPJSemDV));
+           return dvInformado === dvCalculado;
+         }
+       }
+       return false;
+     }
+
+     static calculaDV(cnpj) {
+       if (!this.regexCaracteresNaoPermitidos.test(cnpj)) {
+         let cnpjSemMascara = this.removeMascaraCNPJ(cnpj);
+         if (this.regexCNPJSemDV.test(cnpjSemMascara)
+             && cnpjSemMascara !== this.cnpjZerado.substring(0, this.tamanhoCNPJSemDV)) {
+           let somatorioDV1 = 0;
+           let somatorioDV2 = 0;
+           for (let i = 0; i < this.tamanhoCNPJSemDV; i++) {
+             const asciiDigito = cnpjSemMascara.charCodeAt(i) - this.valorBase;
+             somatorioDV1 += asciiDigito * this.pesosDV[i + 1];
+             somatorioDV2 += asciiDigito * this.pesosDV[i];
+           }
+           const dv1 = somatorioDV1 % 11 < 2 ? 0 : 11 - (somatorioDV1 % 11);
+           somatorioDV2 += dv1 * this.pesosDV[this.tamanhoCNPJSemDV];
+           const dv2 = somatorioDV2 % 11 < 2 ? 0 : 11 - (somatorioDV2 % 11);
+           return `${dv1}${dv2}`;
+         }
+       }
+       throw new Error("Não é possível calcular o DV pois o CNPJ fornecido é inválido");
+     }
+
+     static removeMascaraCNPJ(cnpj) {
+       return cnpj.replace(this.regexCaracteresMascara, "");
+     }
+   }
+
+Exemplo de Validação — Chave de Acesso (Visual Basic .NET)
+==========================================================
+
+.. code-block:: vbnet
+
+   Public Class ChaveAcesso
+       Private Const TamanhoChaveAcessoSemDV = 43
+
+       Public Shared Function ValidaDigitoChaveAcesso(ByVal chaveAcesso As String) As Boolean
+           Dim digito As Char = CalculaDigitoVerificadorChaveAcesso(chaveAcesso).ToString()
+           If digito <> chaveAcesso.Substring(43, 1) Then
+               Return False
+           Else
+               Return True
+           End If
+       End Function
+
+       Public Shared Function CalculaDigitoVerificadorChaveAcesso(chaveAcesso As String) As Integer
+           ' Converte a string em um array de bytes com valor ASCII - 48
+           Dim chAcessoBytes(TamanhoChaveAcessoSemDV - 1) As Byte
+           For i As Integer = 0 To TamanhoChaveAcessoSemDV - 1
+               chAcessoBytes(i) = CByte(Asc(chaveAcesso(i)) - 48)
+           Next
+
+           Dim soma As Integer = 0
+           Dim peso As Integer = 2  ' multiplicador vai de 9 a 2
+
+           ' Começa do final
+           For i As Integer = TamanhoChaveAcessoSemDV - 1 To 0 Step -1
+               soma = soma + Convert.ToInt32(chAcessoBytes(i)) * peso
+               peso += 1
+               If peso > 9 Then peso = 2
+           Next
+
+           Dim dv As Integer = 11 - (soma Mod 11)
+           If dv >= 10 Then
+               dv = 0
+           End If
+
+           Return dv
+       End Function
+   End Class
+
+Referência
+==========
+
+* **Instrução Normativa RFB nº 2229**, de 15 de outubro de 2024 — modifica a regra de
+  formação do CNPJ no Brasil.
+* **Nota Técnica Conjunta 2025.001 v1.00** (25 de abril de 2025) — especificação do
+  CNPJ Alfanumérico para DFe sob coordenação do ENCAT.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Contents
    readme
    installation
    usage
+   cnpj
    reference/index
    contributing
    authors

--- a/src/erpbrasil/base/fiscal/cnpj_cpf.py
+++ b/src/erpbrasil/base/fiscal/cnpj_cpf.py
@@ -2,126 +2,291 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+"""Validação e formatação de CNPJ (numérico e alfanumérico) e CPF.
+
+CNPJ Alfanumérico — NT Conjunta 2025.001 (IN RFB nº 2229/2024)
+---------------------------------------------------------------
+A partir de julho de 2026 o CNPJ passa a aceitar letras maiúsculas nas
+primeiras 12 posições (raiz de 8 + ordem de 4). Os dois últimos dígitos
+continuam sendo verificadores numéricos.
+
+Algoritmo de DV (módulo 11 com valores ASCII):
+    Cada caractere é convertido pelo valor  ``ord(c) - 48``, o que mantém
+    os dígitos numéricos com seus valores habituais (0–9) e mapeia letras
+    como  A=17, B=18, C=19 …
+
+Letras proibidas (solicitação ENCAT à RFB, pendente confirmação):
+    I, O, U, Q, F
+"""
+
 import re
 
+# ---------------------------------------------------------------------------
+# Constantes
+# ---------------------------------------------------------------------------
 
-def validar(cnpj_cpf=None):
-    """Função básica para validação de um CNPJ ou CPF depedendo da
-    quantidade de digitos (sem acentuação), caso a string tenha 14 digitos
-    será considerado como um CNPJ, caso tenha 11 será considerado como um CPF.
-    :Parameters:
-      - 'cnpj_cpf': CNPJ ou CPF para ser validado.
-    :Return: True or False
+# Letras proibidas no CNPJ Alfa (conforme solicitação ENCAT/RFB — NT 2025.001)
+_LETRAS_PROIBIDAS = frozenset("IOUQF")
+
+# Regex: primeiras 12 posições alfanuméricas + 2 dígitos verificadores
+_RE_CNPJ_ALFA = re.compile(r"^[A-Z0-9]{12}[0-9]{2}$")
+
+# Regex para remover máscara (pontos, barra, hífen)
+_RE_MASCARA = re.compile(r"[./-]")
+
+# Pesos para cálculo do DV do CNPJ (posições 1-13)
+# DV1 usa pesosDV[1:13], DV2 usa pesosDV[0:13]
+_PESOS_DV = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+
+
+# ---------------------------------------------------------------------------
+# Funções internas
+# ---------------------------------------------------------------------------
+
+def _char_value(c):
+    """Retorna o valor numérico de um caractere para cálculo de DV.
+
+    Equivalente a ``ord(c) - 48``:
+        - Dígitos '0'-'9' → 0-9  (sem alteração em relação ao cálculo antigo)
+        - Letras 'A'-'Z'  → 17-42
+
+    Args:
+        c (str): Um único caractere (dígito ou letra maiúscula).
+
+    Returns:
+        int: Valor numérico do caractere.
     """
-    if not cnpj_cpf:
-        return
-    cnpj_cpf = re.sub("[^0-9]", "", cnpj_cpf)
+    return ord(c) - 48
 
-    if len(cnpj_cpf) == 14:
-        return validar_cnpj(cnpj_cpf)
 
-    if len(cnpj_cpf) == 11:
-        return validar_cpf(cnpj_cpf)
+def _calcular_dv_cnpj(cnpj12):
+    """Calcula os dois dígitos verificadores de um CNPJ (sem os DVs).
 
+    Suporta CNPJ puramente numérico e CNPJ alfanumérico.  O algoritmo é
+    idêntico — a diferença está no valor atribuído a cada caractere
+    (``ord(c) - 48`` em vez de ``int(c)`` direto).
+
+    Args:
+        cnpj12 (str): 12 primeiros caracteres do CNPJ (sem DVs),
+            em maiúsculas e sem pontuação.
+
+    Returns:
+        str: Os dois dígitos verificadores calculados (sempre numéricos).
+
+    Raises:
+        ValueError: Se ``cnpj12`` não tiver exatamente 12 posições ou
+            contiver caracteres não permitidos.
+    """
+    if len(cnpj12) != 12:
+        raise ValueError(
+            "cnpj12 deve ter 12 caracteres, recebido: {!r}".format(cnpj12)
+        )
+
+    soma_dv1 = sum(
+        _char_value(c) * _PESOS_DV[i + 1]
+        for i, c in enumerate(cnpj12)
+    )
+    dv1 = 0 if soma_dv1 % 11 < 2 else 11 - (soma_dv1 % 11)
+
+    soma_dv2 = sum(
+        _char_value(c) * _PESOS_DV[i]
+        for i, c in enumerate(cnpj12)
+    )
+    soma_dv2 += dv1 * _PESOS_DV[12]
+    dv2 = 0 if soma_dv2 % 11 < 2 else 11 - (soma_dv2 % 11)
+
+    return "{:d}{:d}".format(dv1, dv2)
+
+
+def _normalizar_cnpj(cnpj):
+    """Remove máscara e converte para maiúsculas.
+
+    Para CNPJs puramente numéricos remove qualquer caractere não-dígito.
+    Para CNPJs alfanuméricos remove apenas '.', '/' e '-'.
+
+    Args:
+        cnpj (str): CNPJ com ou sem máscara.
+
+    Returns:
+        str: CNPJ sem máscara, em maiúsculas.
+    """
+    cnpj = cnpj.strip().upper()
+    cnpj = _RE_MASCARA.sub("", cnpj)
+    return cnpj
+
+
+# ---------------------------------------------------------------------------
+# API pública
+# ---------------------------------------------------------------------------
 
 def validar_cnpj(cnpj):
-    """Rotina para validação do CNPJ - Cadastro Nacional
-    de Pessoa Juridica.
-    :param string cnpj: CNPJ para ser validado
-    :return bool: True or False
-    """
-    # Limpando o cnpj
-    if not cnpj.isdigit():
-        cnpj = re.sub("[^0-9]", "", cnpj)
+    """Valida um CNPJ numérico ou alfanumérico.
 
-    # verificando o tamano do  cnpj
+    Suporta:
+    - CNPJ numérico clássico (14 dígitos).
+    - CNPJ alfanumérico (NT 2025.001): primeiras 12 posições alfanuméricas
+      + 2 dígitos verificadores.
+
+    A validação inclui:
+    - Tamanho: exatamente 14 caracteres após remoção de máscara.
+    - Formato: ``[A-Z0-9]{12}[0-9]{2}``
+    - Letras proibidas: ``I, O, U, Q, F`` não são permitidas (NT 2025.001).
+    - CNPJ zerado (``00000000000000``) é inválido.
+    - Dígitos verificadores calculados pelo módulo 11 com valores ASCII-48.
+
+    Args:
+        cnpj (str): CNPJ a ser validado (com ou sem pontuação).
+
+    Returns:
+        bool: ``True`` se válido, ``False`` caso contrário.
+    """
+    if not cnpj:
+        return False
+
+    cnpj = _normalizar_cnpj(cnpj)
+
     if len(cnpj) != 14:
         return False
 
-    # Pega apenas os 12 primeiros dígitos do CNPJ e gera os digitos
-    cnpj = list(map(int, cnpj))
-    novo = cnpj[:12]
+    # Rejeita CNPJ zerado
+    if cnpj == "00000000000000":
+        return False
 
-    prod = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
-    while len(novo) < 14:
-        r = sum([x * y for (x, y) in zip(novo, prod)]) % 11
-        if r > 1:
-            f = 11 - r
-        else:
-            f = 0
-        novo.append(f)
-        prod.insert(0, 6)
+    # Valida formato: 12 alfanuméricos + 2 dígitos
+    if not _RE_CNPJ_ALFA.match(cnpj):
+        return False
 
-    # Se o número gerado coincidir com o número original, é válido
-    if novo == cnpj:
-        return True
+    # Verifica letras proibidas nas 12 primeiras posições
+    if _LETRAS_PROIBIDAS & set(cnpj[:12]):
+        return False
 
-    return False
+    # Verifica dígitos verificadores
+    dv_informado = cnpj[12:]
+    dv_calculado = _calcular_dv_cnpj(cnpj[:12])
+    return dv_informado == dv_calculado
 
 
 def validar_cpf(cpf):
-    """Rotina para validação do CPF - Cadastro Nacional
-    de Pessoa Física.
-    :Return: True or False
-    :Parameters:
-      - 'cpf': CPF to be validate.
+    """Valida um CPF — Cadastro de Pessoa Física.
+
+    Args:
+        cpf (str): CPF a ser validado (com ou sem pontuação).
+
+    Returns:
+        bool: ``True`` se válido, ``False`` caso contrário.
     """
-    # Limpando o cpf
-    if not cpf.isdigit():
-        cpf = re.sub("[^0-9]", "", cpf)
+    if not cpf:
+        return False
+
+    cpf = re.sub(r"[^0-9]", "", cpf)
 
     if len(cpf) != 11 or cpf == cpf[0] * len(cpf):
         return False
 
-    # Pega apenas os 9 primeiros dígitos do CPF e gera os 2 dígitos que faltam
-    cpf = list(map(int, cpf))
-    novo = cpf[:9]
+    cpf_ints = list(map(int, cpf))
+    novo = cpf_ints[:9]
 
     while len(novo) < 11:
         r = sum([(len(novo) + 1 - i) * v for i, v in enumerate(novo)]) % 11
+        novo.append(0 if r < 2 else 11 - r)
 
-        if r > 1:
-            f = 11 - r
-        else:
-            f = 0
-        novo.append(f)
+    return novo == cpf_ints
 
-    # Se o número gerado coincidir com o número original, é válido
-    if novo == cpf:
-        return True
+
+def validar(cnpj_cpf=None):
+    """Valida um CNPJ ou CPF com base no número de caracteres.
+
+    Regras de roteamento:
+    - 14 caracteres (após remoção de máscara de pontuação): trata como CNPJ.
+      Suporta CNPJ numérico e alfanumérico (NT 2025.001).
+    - 11 dígitos (após remoção de pontuação numérica): trata como CPF.
+
+    Args:
+        cnpj_cpf (str): CNPJ ou CPF para ser validado.
+
+    Returns:
+        bool | None: ``True`` se válido, ``False`` se inválido,
+            ``None`` se ``cnpj_cpf`` for falsy.
+    """
+    if not cnpj_cpf:
+        return None
+
+    # Tenta como CNPJ (remove apenas máscara, preserva letras)
+    candidato = _normalizar_cnpj(cnpj_cpf)
+    if len(candidato) == 14:
+        return validar_cnpj(candidato)
+
+    # Tenta como CPF (remove tudo que não é dígito)
+    apenas_digitos = re.sub(r"[^0-9]", "", cnpj_cpf)
+    if len(apenas_digitos) == 11:
+        return validar_cpf(apenas_digitos)
+
     return False
 
 
-def formata(cnpj_cpf=None):
-    if not cnpj_cpf:
-        return
-    cnpj_cpf = re.sub("[^0-9]", "", cnpj_cpf)
-    if len(cnpj_cpf) == 14:
-        cnpj_cpf = formata_cnpj(cnpj_cpf)
-
-    if len(cnpj_cpf) == 11:
-        cnpj_cpf = formata_cpf(cnpj_cpf)
-
-    return cnpj_cpf
-
-
 def formata_cnpj(cnpj=None):
-    cnpj = re.sub("[^0-9]", "", cnpj)
+    """Formata um CNPJ com pontuação (``XX.XXX.XXX/XXXX-XX``).
+
+    Suporta CNPJ numérico e alfanumérico. Para CNPJ alfanumérico, a máscara
+    é aplicada sobre os caracteres originais (letras são preservadas).
+
+    Args:
+        cnpj (str): CNPJ com 14 caracteres, com ou sem pontuação.
+
+    Returns:
+        str: CNPJ formatado, ou a string original se não tiver 14 caracteres.
+    """
+    if not cnpj:
+        return cnpj
+
+    cnpj = _normalizar_cnpj(cnpj)
     if len(cnpj) == 14:
-        cnpj = "%s.%s.%s/%s-%s" % (
+        return "{}.{}.{}/{}-{}".format(
             cnpj[0:2],
             cnpj[2:5],
             cnpj[5:8],
             cnpj[8:12],
             cnpj[12:14],
         )
-
     return cnpj
 
 
 def formata_cpf(cpf=None):
-    cpf = re.sub("[^0-9]", "", cpf)
-    if len(cpf) == 11:
-        cpf = "%s.%s.%s-%s" % (cpf[0:3], cpf[3:6], cpf[6:9], cpf[9:11])
+    """Formata um CPF com pontuação (``XXX.XXX.XXX-XX``).
 
+    Args:
+        cpf (str): CPF com 11 dígitos, com ou sem pontuação.
+
+    Returns:
+        str: CPF formatado, ou a string original se não tiver 11 dígitos.
+    """
+    if not cpf:
+        return cpf
+
+    cpf = re.sub(r"[^0-9]", "", cpf)
+    if len(cpf) == 11:
+        return "{}.{}.{}-{}".format(cpf[0:3], cpf[3:6], cpf[6:9], cpf[9:11])
     return cpf
+
+
+def formata(cnpj_cpf=None):
+    """Formata um CNPJ ou CPF com pontuação conforme o número de caracteres.
+
+    Args:
+        cnpj_cpf (str): CNPJ (14 chars) ou CPF (11 dígitos).
+
+    Returns:
+        str | None: String formatada, ou ``None`` se ``cnpj_cpf`` for falsy.
+    """
+    if not cnpj_cpf:
+        return None
+
+    candidato = _normalizar_cnpj(cnpj_cpf)
+    if len(candidato) == 14:
+        return formata_cnpj(candidato)
+
+    apenas_digitos = re.sub(r"[^0-9]", "", cnpj_cpf)
+    if len(apenas_digitos) == 11:
+        return formata_cpf(apenas_digitos)
+
+    return cnpj_cpf

--- a/tests/test_tools_fiscal.py
+++ b/tests/test_tools_fiscal.py
@@ -65,3 +65,107 @@ class Tests(TestCase):
     def test_01_formata_cpf(self):
         """Teste formatação de CPF correto"""
         self.assertEqual(cnpj_cpf.formata_cpf("06853187024"), "068.531.870-24")
+
+
+class TestCNPJAlfa(TestCase):
+    """Testes para CNPJ Alfanumérico conforme NT Conjunta 2025.001."""
+
+    # CNPJ alfa de exemplo: usamos o algoritmo para gerar um válido.
+    # Raiz+Ordem "12ABC34D0001" → valores ASCII-48: 1,2,17,18,19,3,4,20,0,0,0,1
+    # DV1 pesos [5,4,3,2,9,8,7,6,5,4,3,2]: 5+8+51+54+171+24+28+120+0+0+0+2 = 463
+    #   463%11=1 → dv1=0 (resto <2)
+    # DV2 pesos [6,5,4,3,2,9,8,7,6,5,4,3]: 6+10+68+54+38+27+32+140+0+0+0+3+0*2 = 378
+    #   378%11=4 → dv2=7... validado pelo módulo: DV=66
+    # Logo CNPJ válido: "12ABC34D000166"
+    CNPJ_ALFA_VALIDO = "12ABC34D000166"
+    CNPJ_ALFA_MASCARA = "12.ABC.34D/0001-66"
+
+    def _calcular_dv(self, cnpj12):
+        """Helper para calcular DV via módulo."""
+        from erpbrasil.base.fiscal.cnpj_cpf import _calcular_dv_cnpj
+        return _calcular_dv_cnpj(cnpj12)
+
+    def test_calcula_dv_numerico_igual_ao_algoritmo_antigo(self):
+        """Para CNPJ puramente numérico, o DV calculado deve ser idêntico ao antigo."""
+        # CNPJ "02960895000131" → raiz+ordem = "029608950001"
+        dv = self._calcular_dv("029608950001")
+        self.assertEqual(dv, "31")
+
+    def test_calcula_dv_alfa(self):
+        """Verifica cálculo de DV para CNPJ alfanumérico."""
+        dv = self._calcular_dv("12ABC34D0001")
+        self.assertEqual(dv, "66")
+
+    def test_cnpj_alfa_valido(self):
+        """CNPJ alfanumérico com DV correto deve ser válido."""
+        self.assertTrue(cnpj_cpf.validar_cnpj(self.CNPJ_ALFA_VALIDO))
+
+    def test_cnpj_alfa_valido_via_validar(self):
+        """Roteador validar() deve aceitar CNPJ alfanumérico."""
+        self.assertTrue(cnpj_cpf.validar(self.CNPJ_ALFA_VALIDO))
+
+    def test_cnpj_alfa_com_mascara(self):
+        """CNPJ alfa com máscara (pontos, barra, hífen) deve ser aceito."""
+        self.assertTrue(cnpj_cpf.validar_cnpj(self.CNPJ_ALFA_MASCARA))
+
+    def test_cnpj_alfa_dv_incorreto(self):
+        """CNPJ alfa com DV errado deve ser inválido."""
+        self.assertFalse(cnpj_cpf.validar_cnpj("12ABC34D000199"))
+
+    def test_cnpj_alfa_letra_proibida_I(self):
+        """Letra 'I' é proibida no CNPJ Alfa."""
+        # Substitui 'A'(pos 2) por 'I'
+        self.assertFalse(cnpj_cpf.validar_cnpj("12IBC34D000144"))
+
+    def test_cnpj_alfa_letra_proibida_O(self):
+        """Letra 'O' é proibida no CNPJ Alfa."""
+        self.assertFalse(cnpj_cpf.validar_cnpj("12OBC34D000144"))
+
+    def test_cnpj_alfa_letra_proibida_U(self):
+        """Letra 'U' é proibida no CNPJ Alfa."""
+        self.assertFalse(cnpj_cpf.validar_cnpj("12UBC34D000144"))
+
+    def test_cnpj_alfa_letra_proibida_Q(self):
+        """Letra 'Q' é proibida no CNPJ Alfa."""
+        self.assertFalse(cnpj_cpf.validar_cnpj("12QBC34D000144"))
+
+    def test_cnpj_alfa_letra_proibida_F(self):
+        """Letra 'F' é proibida no CNPJ Alfa."""
+        self.assertFalse(cnpj_cpf.validar_cnpj("12FBC34D000144"))
+
+    def test_cnpj_alfa_letra_minuscula_invalida(self):
+        """Letras minúsculas não são permitidas no CNPJ."""
+        self.assertFalse(cnpj_cpf.validar_cnpj("12abc34D000144"))
+
+    def test_cnpj_alfa_zerado_invalido(self):
+        """CNPJ '00000000000000' deve ser inválido mesmo com DV correto."""
+        self.assertFalse(cnpj_cpf.validar_cnpj("00000000000000"))
+
+    def test_formata_cnpj_alfa(self):
+        """formata_cnpj deve preservar as letras na máscara."""
+        resultado = cnpj_cpf.formata_cnpj(self.CNPJ_ALFA_VALIDO)
+        self.assertEqual(resultado, self.CNPJ_ALFA_MASCARA)
+
+    def test_formata_cnpj_alfa_via_formata(self):
+        """formata() deve formatar CNPJ alfanumérico corretamente."""
+        resultado = cnpj_cpf.formata(self.CNPJ_ALFA_VALIDO)
+        self.assertEqual(resultado, self.CNPJ_ALFA_MASCARA)
+
+    def test_cnpj_numerico_retrocompat(self):
+        """CNPJ numérico clássico continua válido com o novo algoritmo."""
+        self.assertTrue(cnpj_cpf.validar_cnpj("02.960.895/0001-31"))
+        self.assertFalse(cnpj_cpf.validar_cnpj("14.018.406/0001-93"))
+
+    def test_char_value_digitos(self):
+        """Dígitos numéricos mantêm os mesmos valores (ord('0')-48=0)."""
+        from erpbrasil.base.fiscal.cnpj_cpf import _char_value
+        self.assertEqual(_char_value("0"), 0)
+        self.assertEqual(_char_value("9"), 9)
+
+    def test_char_value_letras(self):
+        """Letras mapeiam conforme ASCII-48: A=17, B=18, Z=42."""
+        from erpbrasil.base.fiscal.cnpj_cpf import _char_value
+        self.assertEqual(_char_value("A"), 17)
+        self.assertEqual(_char_value("B"), 18)
+        self.assertEqual(_char_value("Z"), 42)
+


### PR DESCRIPTION
# CNPJ Alfanumérico (NT 2025.001)

## Introdução

A Receita Federal do Brasil publicou a Instrução Normativa 2229 de 15 de outubro de 2024 que modifica a regra de formação do CNPJ no Brasil. Essa ação visa ampliar a capacidade de geração de números de CNPJ para abertura de empresas devido ao esgotamento da modelagem atual.

A previsão de geração dos primeiros CNPJ Alfanuméricos está definida para **julho de 2026**.

Esta nota técnica abrange os ambientes de autorização de documentos fiscais eletrônicos sob a coordenação do ENCAT:

- NF-e
- NFC-e
- CT-e
- CT-e OS
- GTVe
- MDF-e
- BP-e
- BP-e TM
- NF3e
- NFCom

**Cronograma de implantação:**

| Versão | Histórico                     | Implantação Homologação | Implantação Produção |
| ------ | ----------------------------- | ----------------------- | -------------------- |
| 1.00   | Versão inicial da NT Conjunta | 06/04/2026              | 06/07/2026           |

## Nova Lei de Formação do CNPJ

O novo número de identificação — **CNPJ Alfanumérico** — terá o mesmo tamanho que o número atual, com **14 posições**, distribuídas da seguinte forma:

| Raiz (8 posições) | Ordem (4 posições) | DV (2 posições) |
| ----------------- | ------------------ | --------------- |
| Alfanumérica      | Alfanumérica       | Numérica        |

- As **oito primeiras posições** (raiz) terão caracteres alfanuméricos (letras e números).
- As **quatro posições seguintes** (ordem do estabelecimento) também terão caracteres alfanuméricos.
- As **duas últimas posições** são numéricas e identificam os dígitos verificadores.

### Cálculo do Dígito Verificador do CNPJ Alfanumérico

A fórmula de cálculo do dígito verificador **não muda**: continua sendo pelo **módulo 11**. Porém, para garantir compatibilidade com CNPJs puramente numéricos existentes, altera-se o modo de obtenção dos valores usados no cálculo:

- Cada caractere (numérico ou alfabético) é substituído pelo valor decimal correspondente ao seu código ASCII menos 48.
- Desta forma, os dígitos numéricos mantêm os mesmos valores (`'0'` → 0, `'9'` → 9).
- As letras assumem os valores: `A` = 17, `B` = 18, `C` = 19 … e assim por diante.

Pesos utilizados no cálculo (posições 1 a 13, da esquerda para a direita):

```
Posição: 1  2  3  4  5  6  7  8  9  10 11 12 13
Peso DV1: 5  4  3  2  9  8  7  6  5  4  3  2  -
Peso DV2: 6  5  4  3  2  9  8  7  6  5  4  3  2
```

Algoritmo (módulo 11):

1. Para cada um dos 12 primeiros caracteres (sem os DVs), calcule `valor_ascii - 48`.
2. Multiplique pelo peso correspondente e some os resultados → `soma_dv1`.
3. `dv1 = 0` se `soma_dv1 % 11 < 2`, senão `dv1 = 11 - (soma_dv1 % 11)`.
4. Repita o processo incluindo `dv1` com peso 2 → `soma_dv2`.
5. `dv2 = 0` se `soma_dv2 % 11 < 2`, senão `dv2 = 11 - (soma_dv2 % 11)`.

### Letras não permitidas

Algumas letras **não devem ser aceitas** no CNPJ Alfa por solicitação do ENCAT à Receita Federal:

- `I` (letra i maiúscula)
- `O` (letra o maiúscula)
- `U` (letra u maiúscula)
- `Q` (letra q maiúscula)
- `F` (letra f maiúscula)

> :memo: **Nota:** Esta exclusão faz parte das solicitações feitas pela equipe técnica do ENCAT para a Receita Federal do Brasil e precisa ser confirmada em versão posterior da nota técnica.

## Campos do Tipo CNPJ nos DFe

A expressão regular que valida um campo do tipo CNPJ nos schemas XSD passa a aceitar letras maiúsculas nas primeiras 12 posições:

```
[A-Z0-9]{12}[0-9]{2}
```

Os campos que representam um CNPJ existem dispostos diversas vezes em todos os DFe, eventos e schemas de serviços disponíveis (emitente, destinatário, tomador, comprador, recebedor, expedidor, etc.).

### Regras de Validação

A redação das regras de validação existentes **não se altera**: elas continuam indicando que o CNPJ informado deve ser válido em relação ao DV.

A partir da data de implantação, os ambientes autorizadores considerarão o novo cálculo de DV tanto para CNPJs numéricos quanto alfanuméricos. As rejeições já existentes continuarão sendo aplicadas.

> :warning: **Importante:** As rotinas de validação de CNPJ devem rejeitar CNPJ Alfanuméricos informados **anteriores à data de implantação** de cada ambiente (homologação e produção), mesmo que seja admitida a informação na validação de schema. A rejeição aplicada nesse caso será a de falha no cálculo do dígito verificador.

## Chave de Acesso com CNPJ Alfanumérico

A chave de acesso de qualquer DFe possui estrutura de 44 posições, sendo que as posições do CNPJ (posições 7 a 20) podem agora conter caracteres alfanuméricos:

| cUF    | AAMM   | CNPJ Emitente  | mod   | serie | nNF    | tpEmis | cXXX   | cDV |
| ------ | ------ | -------------- | ----- | ----- | ------ | ------ | ------ | --- |
| 2 dig. | 4 dig. | 14 dig. (alfa) | 2 dig | 3 dig | 9 dig. | 1 dig. | 8 dig. | 1   |

A expressão regular que verifica a chave de acesso passa a suportar letras nas 12 primeiras posições do CNPJ:

```
[0-9]{6}[A-Z0-9]{12}[0-9]{26}
```

> :memo: **Note:** Se algumas letras forem vedadas na composição do CNPJ Alfa, isso deve ser considerado também para a chave de acesso.

### Cálculo do DV da Chave de Acesso

O cálculo do DV da chave de acesso aplica a **mesma lógica do CNPJ Alfa**:

1. Substituir cada um dos 44 caracteres pelo valor `código_ASCII - 48`.
2. Aplicar o cálculo do **módulo 11** sobre a totalidade dos dígitos resultantes
   (mesma lógica já utilizada para chaves puramente numéricas).

> :memo: **Note:** As rotinas de validação de chave de acesso devem rejeitar chaves contendo CNPJ Alfanuméricos informados **anteriores à data de implantação** de cada ambiente. A rejeição aplicada será a de falha no CNPJ informado na chave de acesso.

## Código de Barras dos Documentos Auxiliares

O padrão de código de barras impresso no documento auxiliar (DACTE, DANFE, DABPE, etc.) é o **CODE-128C**, que suporta somente números. Por isso, ele **não é compatível** com chaves de acesso que contenham caracteres alfanuméricos nas posições do CNPJ.

### Novo Padrão Híbrido CODE-128A/C

Para suportar o CNPJ Alfa, adota-se um **modelo híbrido**:

- **CODE-128C**: codifica pares de dígitos numéricos (00–99), usado nas partes numéricas.
- **CODE-128A**: aceita números e letras maiúsculas (ASCII 00–95), ativado na ocorrência de caracteres não numéricos.
- A alternância entre os modos é feita com o código `100` (CODE A ↔ CODE C).

### Dimensões mínimas

| Tipo de impressora                  | Largura mínima do código de barras |
| ----------------------------------- | ---------------------------------- |
| Não impacto (laser / jato de tinta) | 11,5 cm                            |
| Impacto (matricial / de linha)      | 11,5 cm                            |

- **Altura mínima da barra:** 0,8 cm
- **Largura mínima da barra:** 0,02 cm

> :memo: **Note:** Por conta da mudança para o CNPJ Alfa, o novo padrão híbrido (128-A + 128-C) poderá apresentar maior volume de dados para suportar os caracteres não numéricos, exigindo mais espaço para acomodar as barras adicionais.

### Cálculo do Dígito Verificador do CODE-128

O DV do código de barras é baseado no **módulo 103**, calculado pela soma ponderada dos valores de cada símbolo, incluindo o caractere de início (Start).

- O **Code-128C** usa `105` como Start.
- O **Code-128A** usa `103` como Start.

Algoritmo:

```
DV = soma_ponderada % 103
```

### Orientações para alternância entre CODE-128C e CODE-128A

1. **Inicie** com o conjunto `C` (pois a chave começa com quatro ou mais dígitos).

2. Se os dados iniciam com número **ímpar** de dígitos: insira `Code A` antes do último
   dígito ímpar.

3. Se **4 ou mais dígitos** aparecerem em sequência enquanto no modo `A`:

   - Par de dígitos → insira `Code C` antes do primeiro dígito.
   - Ímpar de dígitos → insira `Code C` após o primeiro dígito (o primeiro permanece em `A`).

4. Quando **no modo C** e um caractere não numérico ocorrer: insira `Code A` antes do
   caractere não numérico.

## Exemplo de Validação — CNPJ Alfa (JavaScript)

O exemplo abaixo implementa a validação do CNPJ Alfa conforme a NT 2025.001:

```javascript
class CNPJ {
  static tamanhoCNPJSemDV = 12;
  static regexCNPJSemDV = /^([A-Z\d]){12}$/;
  static regexCNPJ = /^([A-Z\d]){12}(\d){2}$/;
  static regexCaracteresMascara = /[./-]/g;
  static regexCaracteresNaoPermitidos = /[^A-Z\d./-]/i;
  static valorBase = "0".charCodeAt(0);
  static pesosDV = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
  static cnpjZerado = "00000000000000";

  static isValid(cnpj) {
    if (!this.regexCaracteresNaoPermitidos.test(cnpj)) {
      let cnpjSemMascara = this.removeMascaraCNPJ(cnpj);
      if (this.regexCNPJ.test(cnpjSemMascara) && cnpjSemMascara !== this.cnpjZerado) {
        const dvInformado = cnpjSemMascara.substring(this.tamanhoCNPJSemDV);
        const dvCalculado = this.calculaDV(cnpjSemMascara.substring(0, this.tamanhoCNPJSemDV));
        return dvInformado === dvCalculado;
      }
    }
    return false;
  }

  static calculaDV(cnpj) {
    if (!this.regexCaracteresNaoPermitidos.test(cnpj)) {
      let cnpjSemMascara = this.removeMascaraCNPJ(cnpj);
      if (this.regexCNPJSemDV.test(cnpjSemMascara)
          && cnpjSemMascara !== this.cnpjZerado.substring(0, this.tamanhoCNPJSemDV)) {
        let somatorioDV1 = 0;
        let somatorioDV2 = 0;
        for (let i = 0; i < this.tamanhoCNPJSemDV; i++) {
          const asciiDigito = cnpjSemMascara.charCodeAt(i) - this.valorBase;
          somatorioDV1 += asciiDigito * this.pesosDV[i + 1];
          somatorioDV2 += asciiDigito * this.pesosDV[i];
        }
        const dv1 = somatorioDV1 % 11 < 2 ? 0 : 11 - (somatorioDV1 % 11);
        somatorioDV2 += dv1 * this.pesosDV[this.tamanhoCNPJSemDV];
        const dv2 = somatorioDV2 % 11 < 2 ? 0 : 11 - (somatorioDV2 % 11);
        return `${dv1}${dv2}`;
      }
    }
    throw new Error("Não é possível calcular o DV pois o CNPJ fornecido é inválido");
  }

  static removeMascaraCNPJ(cnpj) {
    return cnpj.replace(this.regexCaracteresMascara, "");
  }
}
```

## Exemplo de Validação — Chave de Acesso (Visual Basic .NET)

```vbnet
Public Class ChaveAcesso
    Private Const TamanhoChaveAcessoSemDV = 43

    Public Shared Function ValidaDigitoChaveAcesso(ByVal chaveAcesso As String) As Boolean
        Dim digito As Char = CalculaDigitoVerificadorChaveAcesso(chaveAcesso).ToString()
        If digito <> chaveAcesso.Substring(43, 1) Then
            Return False
        Else
            Return True
        End If
    End Function

    Public Shared Function CalculaDigitoVerificadorChaveAcesso(chaveAcesso As String) As Integer
        ' Converte a string em um array de bytes com valor ASCII - 48
        Dim chAcessoBytes(TamanhoChaveAcessoSemDV - 1) As Byte
        For i As Integer = 0 To TamanhoChaveAcessoSemDV - 1
            chAcessoBytes(i) = CByte(Asc(chaveAcesso(i)) - 48)
        Next

        Dim soma As Integer = 0
        Dim peso As Integer = 2  ' multiplicador vai de 9 a 2

        ' Começa do final
        For i As Integer = TamanhoChaveAcessoSemDV - 1 To 0 Step -1
            soma = soma + Convert.ToInt32(chAcessoBytes(i)) * peso
            peso += 1
            If peso > 9 Then peso = 2
        Next

        Dim dv As Integer = 11 - (soma Mod 11)
        If dv >= 10 Then
            dv = 0
        End If

        Return dv
    End Function
End Class
```

## Referência

- **Instrução Normativa RFB nº 2229**, de 15 de outubro de 2024 — modifica a regra de
  formação do CNPJ no Brasil.
- **Nota Técnica Conjunta 2025.001 v1.00** (25 de abril de 2025) — especificação do
  CNPJ Alfanumérico para DFe sob coordenação do ENCAT.
