### PR TITLE
[UPD] Bump Version: 2.4.2, para que a atualização do CNPJ Alfa Numérico esteja disponível via PIP

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.1
+current_version = 2.4.2
 commit = True
 tag = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ project = "erpbrasil.base"
 year = "2019"
 author = "Luis Felipe Mileo"
 copyright = "{0}, {1}".format(year, author)
-version = release = "2.4.1"
+version = release = "2.4.2"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/src/erpbrasil/base/__init__.py
+++ b/src/erpbrasil/base/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 
 from erpbrasil.base.fiscal import *  # noqa: F401,F403
 from erpbrasil.base.misc import *  # noqa: F401,F403


### PR DESCRIPTION
PR simples estou apenas alterando a versão da biblioteca para que ocorra a atualização no PIP, parece que isso acabou faltando no PR https://github.com/erpbrasil/erpbrasil.base/pull/63 , importante verificar se a numeração da versão está correta e se teria algum outro arquivo para ser alterado.